### PR TITLE
Add Pester Api tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,14 +9,18 @@ on:
     branches:
       - main
       - releases/*
-    paths-ignore:
-      - '**.md'
+    paths:
+      - 'TaskSample/**'
+      - '.github/workflows/build-test.yml'
+      - '!TaskSample/**/*.md'
   push:
     branches:
       - main
       - releases/*
-    paths-ignore:
-      - '**.md'
+    paths:
+      - 'TaskSample/**'
+      - '.github/workflows/build-test.yml'
+      - '!TaskSample/**/*.md'
 
 jobs:
   build:

--- a/.github/workflows/pester-api-testing-build.yml
+++ b/.github/workflows/pester-api-testing-build.yml
@@ -1,0 +1,42 @@
+name: Build and Test
+
+# References:
+#  - https://github.com/actions/setup-dotnet/blob/main/.github/workflows/test-dotnet.yml
+#  - https://github.com/marketplace/actions/setup-net-core-sdk
+
+on:
+  pull_request:
+    branches:
+      - main
+      - releases/*
+    paths:
+      - 'pester-api-testing/**'
+      - '.github/workflows/pester-api-testing-build.yml'
+    paths-ignore:
+      - '**.md'
+  push:
+    branches:
+      - *
+    paths:
+      - 'pester-api-testing/**'
+      - '.github/workflows/pester-api-testing-build.yml'
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  pester-test:
+    name: PowerShell Api Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Run Rest-Api Module Tests
+        shell: pwsh
+        run: |
+          Invoke-Pester -Path ./pester-api-testing/Rest-Api.Tests.ps1 -Passthru
+
+      - name: Validate Api Tests Against Production 🤨
+        shell: pwsh
+        run: |
+          ./pester-api-testing/Invoke-ApiTests-Prod.ps1 -Passthru

--- a/.github/workflows/pester-api-testing-build.yml
+++ b/.github/workflows/pester-api-testing-build.yml
@@ -16,7 +16,7 @@ on:
       - '**.md'
   push:
     branches:
-      - *
+      - '*'
     paths:
       - 'pester-api-testing/**'
       - '.github/workflows/pester-api-testing-build.yml'

--- a/.github/workflows/pester-api-testing-build.yml
+++ b/.github/workflows/pester-api-testing-build.yml
@@ -12,16 +12,14 @@ on:
     paths:
       - 'pester-api-testing/**'
       - '.github/workflows/pester-api-testing-build.yml'
-    paths-ignore:
-      - '**.md'
+      - '!pester-api-testing/**/*.md'
   push:
     branches:
       - '*'
     paths:
       - 'pester-api-testing/**'
       - '.github/workflows/pester-api-testing-build.yml'
-    paths-ignore:
-      - '**.md'
+      - '!pester-api-testing/**/*.md'
 
 jobs:
   pester-test:

--- a/pester-api-testing/Invoke-ApiTests-Local.ps1
+++ b/pester-api-testing/Invoke-ApiTests-Local.ps1
@@ -1,0 +1,11 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$here = Split-Path -Path $MyInvocation.MyCommand.Path
+Import-Module $here/Rest-Api.psm1
+Import-Module Pester
+
+$BaseUrl = 'https://localhost:7053/'
+
+Set-ApiBaseUrl -Url $BaseUrl
+
+Invoke-Pester "$here/*.Smoke.Tests.ps1" -Verbose:$VerbosePreference 

--- a/pester-api-testing/Invoke-ApiTests-Prod.ps1
+++ b/pester-api-testing/Invoke-ApiTests-Prod.ps1
@@ -1,0 +1,11 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$here = Split-Path -Path $MyInvocation.MyCommand.Path
+Import-Module $here/Rest-Api.psm1
+Import-Module Pester
+
+$BaseUrl = 'https://postman-load-test.azurewebsites.net/'
+
+Set-ApiBaseUrl -Url $BaseUrl
+
+Invoke-Pester "$here/*.Smoke.Tests.ps1" -Verbose:$VerbosePreference -PassThru

--- a/pester-api-testing/Rest-Api.Tests.ps1
+++ b/pester-api-testing/Rest-Api.Tests.ps1
@@ -1,0 +1,30 @@
+BeforeAll {
+    # Add '-Verbose' to the Module commands to see what it's doing
+    $moduleUnderTest = "Rest-Api"
+    
+    # For troubleshooting, try uncommenting to remove module to ensure proper clean-up
+    #Get-Module -Name "$moduleUnderTest.psm1" -All  | Remove-Module -Force -ErrorAction Ignore
+
+    # Import Module Under Test
+    Import-Module "$PSScriptRoot/$moduleUnderTest.psm1" -Force 
+}
+
+Describe 'Add-ApiResource' {
+    BeforeEach {
+        $commandUnderTest = "Add-ApiResource"
+    }
+
+    It "Should provide help synopsis that is not auto-generated" {
+        $help = Get-Command -CommandType Function -Name $commandUnderTest | Get-Help -ErrorAction SilentlyContinue
+        $help.Synopsis | Should -Not -BeNullOrEmpty
+        $help.Synopsis | Should -Not -BeLike "`n$commandUnderTest `n"
+    }
+
+    It "Should require a parameter named 'Resource'" {
+        (Get-Command $commandUnderTest).Parameters['Resource'].Attributes.Mandatory | Should -BeTrue
+    }
+
+    It "Should allow an optional parameter 'Body' to send as content" {
+        (Get-Command $commandUnderTest).Parameters['Body'].Attributes.Mandatory | Should -BeFalse
+    }
+}

--- a/pester-api-testing/Rest-Api.psm1
+++ b/pester-api-testing/Rest-Api.psm1
@@ -1,0 +1,100 @@
+# Credit to [Derek Graham](https://github.com/deejaygraham) for the original code
+# https://deejaygraham.github.io/2019/05/27/using-pester-for-api-testing/
+
+Set-StrictMode -Version Latest
+
+[string]$script:BaseUrl =  'https://localhost:7053/'
+[hashtable]$script:Headers = @{ }
+
+
+Function Set-ApiBaseUrl {
+    [CmdletBinding()]
+    Param (
+		[Parameter(Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+		[string]$Url
+    )
+	
+	Write-Verbose "Changing api url to $Url"
+	
+	$script:BaseUrl = $Url
+}
+
+
+Function Set-ApiHeaders {
+    [CmdletBinding()]
+    Param (
+		[Parameter(Mandatory=$True)]
+		[hashtable]$Headers
+    )
+
+	$script:Headers = $Headers
+}
+
+
+Function Get-ApiResource {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory=$True, Position=0)]
+        [string]$Resource
+    )
+
+    $Response = Invoke-RestMethod -Method Get -Uri "$($script:BaseUrl)$Resource" -Headers $script:Headers
+
+    Write-Output $Response
+}   
+
+<#
+.SYNOPSIS
+Submits a POST request to the specified resource
+#>
+Function Add-ApiResource {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$True, Position=0)]
+        [string]$Resource,
+
+    	[Parameter(Mandatory=$False, Position=1)]
+	    [hashtable]$Body
+    )
+
+    if($Body) {
+        $Json = $Body | ConvertTo-Json
+        $Response = Invoke-RestMethod -Method Post -Uri "$($script:BaseUrl)$Resource" -Body $Json -Headers $script:Headers
+    } else {
+        $Response = Invoke-RestMethod -Method Post -Uri "$($script:BaseUrl)$Resource" -Headers $script:Headers
+    }
+    # $Response = Invoke-RestMethod -Method Post -Uri "$($script:BaseUrl)$Resource" -Headers $script:Headers -Body $Json -ContentType 'application/json'
+
+    Write-Output $Response
+}
+
+
+Function Set-ApiResource {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$True, Position=0)]
+        [string]$Resource,
+
+    	[Parameter(Mandatory=$True, Position=1)]
+	    [hashtable]$Body
+    )
+
+    $Json = $Body | ConvertTo-Json
+    $Response = Invoke-RestMethod -Method Put -Uri "$($script:BaseUrl)$Resource" -Headers $script:Headers -Body $Json -ContentType 'application/json'
+
+    Write-Output $Response
+}
+
+
+Function Remove-ApiResource {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$True, Position=0)]
+        [string]$Resource
+    )
+
+    $Response = Invoke-RestMethod -Method Delete -Uri "$($script:BaseUrl)$Resource" -Headers $script:Headers
+
+    Write-Output $Response
+}

--- a/pester-api-testing/TaskSample.Smoke.Tests.ps1
+++ b/pester-api-testing/TaskSample.Smoke.Tests.ps1
@@ -1,0 +1,12 @@
+Describe 'Creating Tasks' {
+
+    It 'It should create a task given a title' {
+
+        $expectedTitle = "Test";
+
+        $createdTask = Add-ApiResource "tasks/create?title=$($expectedTitle)"
+
+        $createdTask.title | Should -Be $expectedTitle
+    }
+
+}


### PR DESCRIPTION
Having worked on another Postman-centric API Smoke Test project, it felt like a lot of work and didn't provide a great way to manage personas, etc. So wanted to see how Pester might work to do API testing.